### PR TITLE
Put Accept header value as preformatted code

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To interact with it from your code, you'll need to provide the following HTTP he
 
 HTTP Header | Value
 ------------|------
-Accept | application/vnd.busbud+json; version=2; profile=https://schema.busbud.com/v2/
+Accept | `application/vnd.busbud+json; version=2; profile=https://schema.busbud.com/v2/`
 X-Busbud-Token | value provided in challenge invitation email (if not contact us)
 
 ### Search overview


### PR DESCRIPTION
I believe either GitHub or Chrome (more likely GitHub) is running an experiment where in plain text, URLs are displayed without the protocol and trailing slash, meaning the Accept header value is displayed as `application/vnd.busbud+json; version=2; profile=schema.busbud.com/v2`, which won't be parsed properly by the API and result in an unsupported version error.

This PR fixes this by putting the header value as preformatted code so it's not parsed as a plain text URL and potentially altered.